### PR TITLE
Feat/get follow posts api

### DIFF
--- a/src/main/java/sssdev/tcc/domain/post/controller/PostController.java
+++ b/src/main/java/sssdev/tcc/domain/post/controller/PostController.java
@@ -1,5 +1,6 @@
 package sssdev.tcc.domain.post.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -10,7 +11,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import sssdev.tcc.domain.post.dto.response.PostDetailResponse;
 import sssdev.tcc.domain.post.service.PostService;
+import sssdev.tcc.global.common.dto.LoginUser;
 import sssdev.tcc.global.common.dto.response.RootResponse;
+import sssdev.tcc.global.util.StatusUtil;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,6 +21,7 @@ import sssdev.tcc.global.common.dto.response.RootResponse;
 public class PostController {
 
     private final PostService postService;
+    private final StatusUtil statusUtil; // 세션으로 유저를 가져오는 유틸
 
     /**
      * 게시글 목록 조회
@@ -30,6 +34,22 @@ public class PostController {
         @RequestParam(name = "query", required = false, defaultValue = "") String query) {
 
         Page<PostDetailResponse> postList = postService.getPosts(pageable, query);
+
+        return ResponseEntity.ok(RootResponse.<Page<PostDetailResponse>>builder()
+            .data(postList)
+            .build());
+    }
+
+    /**
+     * 팔로우 중인 사람의 게시글 목록 조회
+     */
+    @GetMapping("/follow")
+    public ResponseEntity<RootResponse<Page<PostDetailResponse>>> getFollowPosts(
+        Pageable pageable,
+        HttpServletRequest request) {
+
+        LoginUser loginUser = statusUtil.getLoginUser(request);
+        Page<PostDetailResponse> postList = postService.getFollowingPosts(loginUser, pageable);
 
         return ResponseEntity.ok(RootResponse.<Page<PostDetailResponse>>builder()
             .data(postList)

--- a/src/main/java/sssdev/tcc/domain/post/repository/PostRepository.java
+++ b/src/main/java/sssdev/tcc/domain/post/repository/PostRepository.java
@@ -1,5 +1,6 @@
 package sssdev.tcc.domain.post.repository;
 
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,4 +9,6 @@ import sssdev.tcc.domain.post.domain.Post;
 public interface PostRepository extends PostReadRepository, JpaRepository<Post, Long> {
 
     Page<Post> findAllByContentContaining(String query, Pageable pageable);
+
+    Page<Post> findAllByUserIdIn(List<Long> followingUserIdList, Pageable pageable);
 }

--- a/src/main/java/sssdev/tcc/domain/post/service/PostService.java
+++ b/src/main/java/sssdev/tcc/domain/post/service/PostService.java
@@ -1,20 +1,30 @@
 package sssdev.tcc.domain.post.service;
 
+import static sssdev.tcc.global.execption.ErrorCode.NOT_EXIST_USER;
+
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import sssdev.tcc.domain.comment.repository.CommentRepository;
 import sssdev.tcc.domain.post.dto.response.PostDetailResponse;
 import sssdev.tcc.domain.post.repository.PostLikeRepository;
 import sssdev.tcc.domain.post.repository.PostRepository;
+import sssdev.tcc.domain.user.domain.User;
+import sssdev.tcc.domain.user.repository.UserRepository;
+import sssdev.tcc.global.common.dto.LoginUser;
+import sssdev.tcc.global.execption.ServiceException;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class PostService {
 
+    private final UserRepository userRepository;
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
     private final PostLikeRepository postLikeRepository;
@@ -30,6 +40,23 @@ public class PostService {
         }
 
         return postRepository.findAllByContentContaining(query, pageable)
+            .map(post -> PostDetailResponse.of(post, commentRepository, postLikeRepository));
+    }
+
+    /**
+     * 팔로우 중인 사람들의 게시글 목록을 가져옴.
+     */
+    public Page<PostDetailResponse> getFollowingPosts(LoginUser loginUser, Pageable pageable) {
+
+        User user = userRepository.findById(loginUser.id())
+            .orElseThrow(() -> new ServiceException(NOT_EXIST_USER));
+
+        List<Long> followingUserIdList = user.getFollowingList()
+            .stream()
+            .map(follow -> follow.getTo().getId())
+            .toList();
+
+        return postRepository.findAllByUserIdIn(followingUserIdList, pageable)
             .map(post -> PostDetailResponse.of(post, commentRepository, postLikeRepository));
     }
 }

--- a/src/main/java/sssdev/tcc/domain/post/service/PostService.java
+++ b/src/main/java/sssdev/tcc/domain/post/service/PostService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -55,7 +56,8 @@ public class PostService {
         User user = userRepository.findById(loginUser.id())
             .orElseThrow(() -> new ServiceException(NOT_EXIST_USER));
 
-        List<Long> followingUserIdList = followRepository.findAllFollowIdByFromId(user.getId());
+        List<Long> followingUserIdList = followRepository.findAllFollowIdByFromId(user.getId(),
+            PageRequest.of(0, 10));
 
         return postRepository.findAllByUserIdIn(followingUserIdList, pageable)
             .map(post -> PostDetailResponse.of(post, commentRepository, postLikeRepository));

--- a/src/main/java/sssdev/tcc/domain/post/service/PostService.java
+++ b/src/main/java/sssdev/tcc/domain/post/service/PostService.java
@@ -14,6 +14,7 @@ import sssdev.tcc.domain.post.dto.response.PostDetailResponse;
 import sssdev.tcc.domain.post.repository.PostLikeRepository;
 import sssdev.tcc.domain.post.repository.PostRepository;
 import sssdev.tcc.domain.user.domain.User;
+import sssdev.tcc.domain.user.repository.FollowRepository;
 import sssdev.tcc.domain.user.repository.UserRepository;
 import sssdev.tcc.global.common.dto.LoginUser;
 import sssdev.tcc.global.execption.ServiceException;
@@ -28,6 +29,7 @@ public class PostService {
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
     private final PostLikeRepository postLikeRepository;
+    private final FollowRepository followRepository;
 
     /**
      * 모든 게시글을 가져옴. query 값이 존재하면 query 포함 게시글을 가져옴
@@ -51,10 +53,7 @@ public class PostService {
         User user = userRepository.findById(loginUser.id())
             .orElseThrow(() -> new ServiceException(NOT_EXIST_USER));
 
-        List<Long> followingUserIdList = user.getFollowingList()
-            .stream()
-            .map(follow -> follow.getTo().getId())
-            .toList();
+        List<Long> followingUserIdList = followRepository.findAllFollowIdByFromId(user.getId());
 
         return postRepository.findAllByUserIdIn(followingUserIdList, pageable)
             .map(post -> PostDetailResponse.of(post, commentRepository, postLikeRepository));

--- a/src/main/java/sssdev/tcc/domain/post/service/PostService.java
+++ b/src/main/java/sssdev/tcc/domain/post/service/PostService.java
@@ -59,6 +59,7 @@ public class PostService {
 
         return postRepository.findAllByUserIdIn(followingUserIdList, pageable)
             .map(post -> PostDetailResponse.of(post, commentRepository, postLikeRepository));
+    }
 
     // todo 
     public AdminPostUpdateResponse updatePost(Long id, AdminPostUpdateRequest request) {

--- a/src/main/java/sssdev/tcc/domain/user/repository/FollowRepository.java
+++ b/src/main/java/sssdev/tcc/domain/user/repository/FollowRepository.java
@@ -1,6 +1,9 @@
 package sssdev.tcc.domain.user.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import sssdev.tcc.domain.user.domain.Follow;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
@@ -8,4 +11,7 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     long countFollowerByToId(Long from_id);
 
     long countFollowingByFromId(Long from_id);
+
+    @Query("select u.id from Follow f join User u on f.to.id = u.id where f.from.id = :fromId")
+    List<Long> findAllFollowIdByFromId(@Param("fromId") Long fromId);
 }

--- a/src/main/java/sssdev/tcc/domain/user/repository/FollowRepository.java
+++ b/src/main/java/sssdev/tcc/domain/user/repository/FollowRepository.java
@@ -1,6 +1,7 @@
 package sssdev.tcc.domain.user.repository;
 
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,5 +14,5 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     long countFollowingByFromId(Long from_id);
 
     @Query("select u.id from Follow f join User u on f.to.id = u.id where f.from.id = :fromId")
-    List<Long> findAllFollowIdByFromId(@Param("fromId") Long fromId);
+    List<Long> findAllFollowIdByFromId(@Param("fromId") Long fromId, Pageable pageable);
 }

--- a/src/test/java/sssdev/tcc/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/sssdev/tcc/domain/post/controller/PostControllerTest.java
@@ -30,6 +30,7 @@ import sssdev.tcc.domain.post.dto.response.PostDetailResponse;
 import sssdev.tcc.domain.post.repository.PostLikeRepository;
 import sssdev.tcc.domain.post.service.PostService;
 import sssdev.tcc.domain.user.domain.User;
+import sssdev.tcc.domain.user.domain.UserRole;
 import sssdev.tcc.global.common.dto.LoginUser;
 import sssdev.tcc.global.util.StatusUtil;
 import sssdev.tcc.support.ControllerTest;
@@ -150,7 +151,7 @@ class PostControllerTest extends ControllerTest {
         @Test
         void get_following_posts_success() throws Exception {
             // given
-            LoginUser loginUser = new LoginUser(1L);
+            LoginUser loginUser = new LoginUser(1L, UserRole.USER);
 
             User user1 = User.builder().username("username01").build();
             setField(user1, "id", 1L);

--- a/src/test/java/sssdev/tcc/domain/post/service/PostServiceTest.java
+++ b/src/test/java/sssdev/tcc/domain/post/service/PostServiceTest.java
@@ -28,6 +28,7 @@ import sssdev.tcc.domain.post.dto.response.PostDetailResponse;
 import sssdev.tcc.domain.post.repository.PostLikeRepository;
 import sssdev.tcc.domain.post.repository.PostRepository;
 import sssdev.tcc.domain.user.domain.User;
+import sssdev.tcc.domain.user.domain.UserRole;
 import sssdev.tcc.domain.user.repository.FollowRepository;
 import sssdev.tcc.domain.user.repository.UserRepository;
 import sssdev.tcc.global.common.dto.LoginUser;
@@ -126,7 +127,7 @@ class PostServiceTest {
             setField(user2, "id", 2L);
 
             user1.follow(user2);
-            LoginUser loginUser = new LoginUser(user1.getId());
+            LoginUser loginUser = new LoginUser(user1.getId(), UserRole.USER);
 
             Post post1 = Post.builder().content("content01").user(user1).build();
             setField(post1, "id", 1L);
@@ -167,7 +168,7 @@ class PostServiceTest {
         @Test
         void get_following_posts_fail_not_exist_user() {
             // given
-            LoginUser loginUser = new LoginUser(1L);
+            LoginUser loginUser = new LoginUser(1L, UserRole.USER);
             Pageable pageable = PageRequest.of(0, 10);
 
             given(userRepository.findById(anyLong()))

--- a/src/test/java/sssdev/tcc/domain/post/service/PostServiceTest.java
+++ b/src/test/java/sssdev/tcc/domain/post/service/PostServiceTest.java
@@ -1,10 +1,14 @@
 package sssdev.tcc.domain.post.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
+import static sssdev.tcc.global.execption.ErrorCode.NOT_EXIST_USER;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -17,12 +21,17 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import sssdev.tcc.domain.comment.repository.CommentRepository;
 import sssdev.tcc.domain.post.domain.Post;
 import sssdev.tcc.domain.post.dto.response.PostDetailResponse;
 import sssdev.tcc.domain.post.repository.PostLikeRepository;
 import sssdev.tcc.domain.post.repository.PostRepository;
 import sssdev.tcc.domain.user.domain.User;
+import sssdev.tcc.domain.user.repository.UserRepository;
+import sssdev.tcc.global.common.dto.LoginUser;
+import sssdev.tcc.global.execption.ErrorCode;
+import sssdev.tcc.global.execption.ServiceException;
 
 @DisplayName("게시글 서비스 테스트")
 @ExtendWith(MockitoExtension.class)
@@ -30,6 +39,9 @@ class PostServiceTest {
 
     @Mock
     PostRepository postRepository;
+
+    @Mock
+    UserRepository userRepository;
 
     @Mock
     CommentRepository commentRepository;
@@ -98,6 +110,76 @@ class PostServiceTest {
             assertThat(posts.getContent().size()).isEqualTo(1);
             assertThat(posts.getContent().get(0).content()).isEqualTo(post1.getContent());
             assertThat(posts.getContent().get(0).username()).isEqualTo(user.getUsername());
+        }
+
+        @DisplayName("성공 케이스 - 팔로잉 게시글")
+        @Test
+        void get_following_posts_success() {
+            // given
+            User user1 = User.builder().username("username").build();
+            setField(user1, "id", 1L);
+            User user2 = User.builder().username("username").build();
+            setField(user2, "id", 2L);
+
+            user1.follow(user2);
+            LoginUser loginUser = new LoginUser(user1.getId());
+
+            Post post1 = Post.builder().content("content01").user(user1).build();
+            setField(post1, "id", 1L);
+            Post post2 = Post.builder().content("content02").user(user2).build();
+            setField(post2, "id", 2L);
+            Post post3 = Post.builder().content("content03").user(user2).build();
+            setField(post3, "id", 3L);
+
+            List<Long> followingUserIdList = user1.getFollowingList()
+                .stream()
+                .map(follow -> follow.getTo().getId())
+                .toList();
+
+            List<Post> postList = Stream.of(post1, post2, post3)
+                .filter(post -> user1.getFollowingList()
+                    .stream()
+                    .map(follow -> follow.getTo().getId())
+                    .anyMatch(id -> post.getUser().getId().equals(id)))
+                .toList();
+
+            Pageable pageable = PageRequest.of(0, 10);
+
+            Page<Post> pageResult = new PageImpl<>(
+                postList,
+                pageable,
+                2);
+
+            given(userRepository.findById(user1.getId())).willReturn(Optional.of(user1));
+            given(postRepository.findAllByUserIdIn(followingUserIdList, pageable))
+                .willReturn(pageResult);
+
+            // when
+            Page<PostDetailResponse> posts = postService.getFollowingPosts(loginUser, pageable);
+
+            // then
+            assertThat(posts.getContent().size()).isEqualTo(2);
+        }
+
+        @DisplayName("실패 케이스 - 사용자가 없음")
+        @Test
+        void get_following_posts_fail_not_exist_user() {
+            // given
+            LoginUser loginUser = new LoginUser(1L);
+            Pageable pageable = PageRequest.of(0, 10);
+
+            given(userRepository.findById(anyLong()))
+                .willThrow(new ServiceException(NOT_EXIST_USER));
+
+            // when & then
+            assertThatThrownBy(() -> postService.getFollowingPosts(loginUser, pageable))
+                .isInstanceOf(ServiceException.class)
+                .satisfies(exception -> {
+                    ErrorCode errorCode = ((ServiceException) exception).getCode();
+                    assertThat(errorCode.getMessage()).isEqualTo("사용자가 없습니다.");
+                    assertThat(errorCode.getCode()).isEqualTo("1000");
+                    assertThat(errorCode.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+                });
         }
     }
 }

--- a/src/test/java/sssdev/tcc/domain/post/service/PostServiceTest.java
+++ b/src/test/java/sssdev/tcc/domain/post/service/PostServiceTest.java
@@ -137,7 +137,7 @@ class PostServiceTest {
             setField(post3, "id", 3L);
 
             List<Long> followingUserIdList = followRepository
-                .findAllFollowIdByFromId(user1.getId());
+                .findAllFollowIdByFromId(user1.getId(), PageRequest.of(0, 10));
 
             List<Post> postList = Stream.of(post1, post2, post3)
                 .filter(post -> user1.getFollowingList()

--- a/src/test/java/sssdev/tcc/domain/post/service/PostServiceTest.java
+++ b/src/test/java/sssdev/tcc/domain/post/service/PostServiceTest.java
@@ -28,6 +28,7 @@ import sssdev.tcc.domain.post.dto.response.PostDetailResponse;
 import sssdev.tcc.domain.post.repository.PostLikeRepository;
 import sssdev.tcc.domain.post.repository.PostRepository;
 import sssdev.tcc.domain.user.domain.User;
+import sssdev.tcc.domain.user.repository.FollowRepository;
 import sssdev.tcc.domain.user.repository.UserRepository;
 import sssdev.tcc.global.common.dto.LoginUser;
 import sssdev.tcc.global.execption.ErrorCode;
@@ -48,6 +49,9 @@ class PostServiceTest {
 
     @Mock
     PostLikeRepository postLikeRepository;
+
+    @Mock
+    FollowRepository followRepository;
 
     @InjectMocks
     PostService postService;
@@ -131,10 +135,8 @@ class PostServiceTest {
             Post post3 = Post.builder().content("content03").user(user2).build();
             setField(post3, "id", 3L);
 
-            List<Long> followingUserIdList = user1.getFollowingList()
-                .stream()
-                .map(follow -> follow.getTo().getId())
-                .toList();
+            List<Long> followingUserIdList = followRepository
+                .findAllFollowIdByFromId(user1.getId());
 
             List<Post> postList = Stream.of(post1, post2, post3)
                 .filter(post -> user1.getFollowingList()

--- a/src/test/java/sssdev/tcc/domain/user/repository/FollowRepositoryTest.java
+++ b/src/test/java/sssdev/tcc/domain/user/repository/FollowRepositoryTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 import sssdev.tcc.domain.user.domain.Follow;
 import sssdev.tcc.domain.user.domain.User;
 import sssdev.tcc.support.RepositoryTest;
@@ -97,7 +98,8 @@ class FollowRepositoryTest extends RepositoryTest {
 
         userA.follow(userB);
 
-        List<Long> followingIdList = followRepository.findAllFollowIdByFromId(userA.getId());
+        List<Long> followingIdList = followRepository.findAllFollowIdByFromId(userA.getId(),
+            PageRequest.of(0, 10));
 
         assertThat(followingIdList).size().isEqualTo(1);
         assertThat(followingIdList.get(0)).isEqualTo(userB.getId());

--- a/src/test/java/sssdev/tcc/domain/user/repository/FollowRepositoryTest.java
+++ b/src/test/java/sssdev/tcc/domain/user/repository/FollowRepositoryTest.java
@@ -1,7 +1,9 @@
 package sssdev.tcc.domain.user.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
 
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -72,5 +74,32 @@ class FollowRepositoryTest extends RepositoryTest {
         long followingCount = userA.getFollowingCount(followRepository);
         // then
         then(followingCount).isEqualTo(1);
+    }
+
+    @DisplayName("특정 id의 유저가 팔로잉하는 유저들의 id 목록 반환 확인")
+    @Test
+    void test1() {
+        User userA = userRepository.save(User.builder()
+            .password("test")
+            .username("from")
+            .profileUrl("/api/test.png")
+            .description("description")
+            .nickname("핑크 공주1")
+            .build());
+
+        User userB = userRepository.save(User.builder()
+            .password("test")
+            .username("to")
+            .profileUrl("/api/test.png")
+            .description("description")
+            .nickname("핑크 공주2")
+            .build());
+
+        userA.follow(userB);
+
+        List<Long> followingIdList = followRepository.findAllFollowIdByFromId(userA.getId());
+
+        assertThat(followingIdList).size().isEqualTo(1);
+        assertThat(followingIdList.get(0)).isEqualTo(userB.getId());
     }
 }


### PR DESCRIPTION
## 개요
팔로잉 하는 유저의 게시글 목록 조회 API 추가 

## 작업사항
- 팔로잉 게시글 목록 조회 API 추가
- 컨트롤러 테스트 추가
- 서비스 테스트 추가 

## 변경로직
- 없음. 

## 관련 이슈
- #22 
