### PR TITLE
feat(monitor) : Prometheus 연동 설정

### DIFF
--- a/src/main/java/sssdev/tcc/global/config/MonitoringConfig.java
+++ b/src/main/java/sssdev/tcc/global/config/MonitoringConfig.java
@@ -1,0 +1,15 @@
+package sssdev.tcc.global.config;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MonitoringConfig {
+
+    @Bean
+    MeterRegistryCustomizer<MeterRegistry> metricsCommonTags() {
+        return registry -> registry.config().commonTags("application", "MYAPPNAME");
+    }
+}

--- a/src/main/java/sssdev/tcc/global/config/SecurityConfig.java
+++ b/src/main/java/sssdev/tcc/global/config/SecurityConfig.java
@@ -1,0 +1,22 @@
+package sssdev.tcc.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain setting(HttpSecurity http) throws Exception {
+
+        http.authorizeHttpRequests(
+            c -> {
+                c.requestMatchers("/actuator/**").permitAll();
+            }
+        );
+
+        return http.build();
+    }
+}


### PR DESCRIPTION
## 개요
매트릭 정보를 Prometheus가 접근하여 조회할 수 있도록 API 접속 권한 설정을 추가하고 Spring boot 대시보드를 사용하기 위해서 매트릭 정보(테그)를 추가했습니다.

## 작업사항
- application 테그 정보 설정
- metric 정보 조회를 위한 시큐리티 설정

## 변경로직
- 없음

## 관련 이슈
- #35 
