### PR TITLE
댓글 조회 API

### DIFF
--- a/src/main/java/sssdev/tcc/domain/comment/controller/CommentController.java
+++ b/src/main/java/sssdev/tcc/domain/comment/controller/CommentController.java
@@ -38,4 +38,19 @@ public class CommentController {
                 .message("해당 게시물의 모든 댓글을 가져왔습니다.")
                 .data(responseList).build());
     }
+
+    @PostMapping("/comments")
+    public ResponseEntity<?> createComments(
+        @RequestBody CommentCreateRequest requestDto,
+        HttpServletRequest servletRequest) {
+
+        LoginUser loginUser = statusUtil.getLoginUser(servletRequest);
+        CommentResponse commentResponse = commentService.createComments(loginUser, requestDto);
+
+        return ResponseEntity.ok(RootResponse.builder()
+            .code("200")
+            .message("댓글 생성 성공")
+            .data(commentResponse)
+            .build());
+    }
 }

--- a/src/main/java/sssdev/tcc/domain/comment/controller/CommentController.java
+++ b/src/main/java/sssdev/tcc/domain/comment/controller/CommentController.java
@@ -1,5 +1,42 @@
 package sssdev.tcc.domain.comment.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sssdev.tcc.domain.comment.dto.request.CommentRequest;
+import sssdev.tcc.domain.comment.dto.response.CommentResponse;
+import sssdev.tcc.domain.comment.service.CommentService;
+import sssdev.tcc.global.common.dto.response.RootResponse;
+import sssdev.tcc.global.util.StatusUtil;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
 public class CommentController {
 
+    private final CommentService commentService;
+    private final StatusUtil statusUtil;
+
+    @GetMapping("/comments")
+    public ResponseEntity<?> getComments(HttpServletRequest servletRequest,
+        @RequestBody CommentRequest request) {
+        if (!statusUtil.loginStatus(servletRequest)) {
+            List<CommentResponse> responseList = commentService.getCommentsNonLogin(
+                request.postId());
+            return ResponseEntity.ok(
+                RootResponse.builder()
+                    .code("200")
+                    .message("해당 게시물의 모든 댓글을 가져왔습니다.")
+                    .data(responseList)
+                    .build()
+            );
+        }
+
+        return null;
+    }
 }

--- a/src/main/java/sssdev/tcc/domain/comment/controller/CommentController.java
+++ b/src/main/java/sssdev/tcc/domain/comment/controller/CommentController.java
@@ -5,9 +5,11 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import sssdev.tcc.domain.comment.dto.request.CommentCreateRequest;
 import sssdev.tcc.domain.comment.dto.request.CommentRequest;
 import sssdev.tcc.domain.comment.dto.response.CommentResponse;
 import sssdev.tcc.domain.comment.service.CommentService;
@@ -26,15 +28,11 @@ public class CommentController {
     @GetMapping("/comments")
     public ResponseEntity<?> getComments(HttpServletRequest servletRequest,
         @RequestBody CommentRequest request) {
-        if (!statusUtil.loginStatus(servletRequest)) {
-            List<CommentResponse> responseList = commentService.getCommentsNonLogin(request.postId());
-            return ResponseEntity.ok(
-                RootResponse.builder().code("200")
-                    .message("해당 게시물의 모든 댓글을 가져왔습니다.")
-                    .data(responseList).build());
+        LoginUser loginUser = null;
+        if (statusUtil.isLogin(servletRequest)) {
+            loginUser = statusUtil.getLoginUser(servletRequest);
         }
-        LoginUser loginUser = statusUtil.getLoginUser(servletRequest);
-        List<CommentResponse> responseList = commentService.getCommentsLogin(request.postId(), loginUser);
+        List<CommentResponse> responseList = commentService.getComments(request.postId(), loginUser);
         return ResponseEntity.ok(
             RootResponse.builder().code("200")
                 .message("해당 게시물의 모든 댓글을 가져왔습니다.")

--- a/src/main/java/sssdev/tcc/domain/comment/controller/CommentController.java
+++ b/src/main/java/sssdev/tcc/domain/comment/controller/CommentController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import sssdev.tcc.domain.comment.dto.request.CommentRequest;
 import sssdev.tcc.domain.comment.dto.response.CommentResponse;
 import sssdev.tcc.domain.comment.service.CommentService;
+import sssdev.tcc.global.common.dto.LoginUser;
 import sssdev.tcc.global.common.dto.response.RootResponse;
 import sssdev.tcc.global.util.StatusUtil;
 
@@ -26,17 +27,17 @@ public class CommentController {
     public ResponseEntity<?> getComments(HttpServletRequest servletRequest,
         @RequestBody CommentRequest request) {
         if (!statusUtil.loginStatus(servletRequest)) {
-            List<CommentResponse> responseList = commentService.getCommentsNonLogin(
-                request.postId());
+            List<CommentResponse> responseList = commentService.getCommentsNonLogin(request.postId());
             return ResponseEntity.ok(
-                RootResponse.builder()
-                    .code("200")
+                RootResponse.builder().code("200")
                     .message("해당 게시물의 모든 댓글을 가져왔습니다.")
-                    .data(responseList)
-                    .build()
-            );
+                    .data(responseList).build());
         }
-
-        return null;
+        LoginUser loginUser = statusUtil.getLoginUser(servletRequest);
+        List<CommentResponse> responseList = commentService.getCommentsLogin(request.postId(), loginUser);
+        return ResponseEntity.ok(
+            RootResponse.builder().code("200")
+                .message("해당 게시물의 모든 댓글을 가져왔습니다.")
+                .data(responseList).build());
     }
 }

--- a/src/main/java/sssdev/tcc/domain/comment/dto/CommentCreateRequest.java
+++ b/src/main/java/sssdev/tcc/domain/comment/dto/CommentCreateRequest.java
@@ -1,5 +1,0 @@
-package sssdev.tcc.domain.comment.dto;
-
-public record CommentCreateRequest() {
-
-}

--- a/src/main/java/sssdev/tcc/domain/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/sssdev/tcc/domain/comment/dto/request/CommentCreateRequest.java
@@ -1,0 +1,5 @@
+package sssdev.tcc.domain.comment.dto.request;
+
+public record CommentCreateRequest() {
+
+}

--- a/src/main/java/sssdev/tcc/domain/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/sssdev/tcc/domain/comment/dto/request/CommentCreateRequest.java
@@ -1,5 +1,8 @@
 package sssdev.tcc.domain.comment.dto.request;
 
-public record CommentCreateRequest() {
+public record CommentCreateRequest(
+    String content,
+    Long postId
+) {
 
 }

--- a/src/main/java/sssdev/tcc/domain/comment/dto/request/CommentRequest.java
+++ b/src/main/java/sssdev/tcc/domain/comment/dto/request/CommentRequest.java
@@ -1,0 +1,8 @@
+package sssdev.tcc.domain.comment.dto.request;
+
+public record CommentRequest(
+    Long postId
+)
+{
+
+}

--- a/src/main/java/sssdev/tcc/domain/comment/dto/response/CommentResponse.java
+++ b/src/main/java/sssdev/tcc/domain/comment/dto/response/CommentResponse.java
@@ -3,7 +3,7 @@ package sssdev.tcc.domain.comment.dto.response;
 public record CommentResponse(
     String writer,
     String content,
-    boolean likeStatus
+    Boolean likeStatus
 ) {
 
 }

--- a/src/main/java/sssdev/tcc/domain/comment/dto/response/CommentResponse.java
+++ b/src/main/java/sssdev/tcc/domain/comment/dto/response/CommentResponse.java
@@ -1,0 +1,9 @@
+package sssdev.tcc.domain.comment.dto.response;
+
+public record CommentResponse(
+    String writer,
+    String content,
+    boolean likeStatus
+) {
+
+}

--- a/src/main/java/sssdev/tcc/domain/comment/dto/response/CommentResponse.java
+++ b/src/main/java/sssdev/tcc/domain/comment/dto/response/CommentResponse.java
@@ -1,9 +1,12 @@
 package sssdev.tcc.domain.comment.dto.response;
 
+import lombok.Builder;
+import sssdev.tcc.domain.comment.domain.Comment;
+
+@Builder
 public record CommentResponse(
     String writer,
     String content,
     Boolean likeStatus
 ) {
-
 }

--- a/src/main/java/sssdev/tcc/domain/comment/repository/CommentLikeRepoisoty.java
+++ b/src/main/java/sssdev/tcc/domain/comment/repository/CommentLikeRepoisoty.java
@@ -1,0 +1,8 @@
+package sssdev.tcc.domain.comment.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sssdev.tcc.domain.comment.domain.CommentLike;
+
+public interface CommentLikeRepoisoty extends JpaRepository<CommentLike, Long> {
+
+}

--- a/src/main/java/sssdev/tcc/domain/comment/repository/CommentLikeRepoisoty.java
+++ b/src/main/java/sssdev/tcc/domain/comment/repository/CommentLikeRepoisoty.java
@@ -1,8 +1,11 @@
 package sssdev.tcc.domain.comment.repository;
 
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import sssdev.tcc.domain.comment.domain.CommentLike;
 
 public interface CommentLikeRepoisoty extends JpaRepository<CommentLike, Long> {
 
+    List<CommentLike> findByUserId(Long id);
 }

--- a/src/main/java/sssdev/tcc/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/sssdev/tcc/domain/comment/repository/CommentRepository.java
@@ -1,9 +1,11 @@
 package sssdev.tcc.domain.comment.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import sssdev.tcc.domain.comment.domain.Comment;
 
 public interface CommentRepository extends CommentReadRepository, JpaRepository<Comment, Long> {
+    List<Comment> findAllByPostId(Long id);
 
-    long countByPostId(Long postId);
+    long countByPostId(Long id);
 }

--- a/src/main/java/sssdev/tcc/domain/comment/service/CommentService.java
+++ b/src/main/java/sssdev/tcc/domain/comment/service/CommentService.java
@@ -11,6 +11,8 @@ import sssdev.tcc.domain.comment.dto.request.CommentCreateRequest;
 import sssdev.tcc.domain.comment.dto.response.CommentResponse;
 import sssdev.tcc.domain.comment.repository.CommentLikeRepoisoty;
 import sssdev.tcc.domain.comment.repository.CommentRepository;
+import sssdev.tcc.domain.post.repository.PostRepository;
+import sssdev.tcc.domain.user.repository.UserRepository;
 import sssdev.tcc.global.common.dto.LoginUser;
 
 @Service
@@ -19,6 +21,8 @@ public class CommentService {
 
     private final CommentRepository commentRepository;
     private final CommentLikeRepoisoty commentLikeRepoisoty;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
 
     public List<CommentResponse> getComments(Long postId, LoginUser loginUser) {
         List<Comment> commentList = commentRepository.findAllByPostId(postId);
@@ -47,6 +51,8 @@ public class CommentService {
         return responseList;
     }
 
+    public CommentResponse createComments(LoginUser loginUser, CommentCreateRequest requestDto) {
+    }
 
     // todo
     public void deleteComment(Long id) {
@@ -56,4 +62,5 @@ public class CommentService {
     public void deletePost(Long id) {
 
     }
+
 }

--- a/src/main/java/sssdev/tcc/domain/comment/service/CommentService.java
+++ b/src/main/java/sssdev/tcc/domain/comment/service/CommentService.java
@@ -2,9 +2,12 @@ package sssdev.tcc.domain.comment.service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import sssdev.tcc.domain.comment.domain.Comment;
+import sssdev.tcc.domain.comment.domain.CommentLike;
+import sssdev.tcc.domain.comment.dto.request.CommentCreateRequest;
 import sssdev.tcc.domain.comment.dto.response.CommentResponse;
 import sssdev.tcc.domain.comment.repository.CommentLikeRepoisoty;
 import sssdev.tcc.domain.comment.repository.CommentRepository;
@@ -17,22 +20,40 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final CommentLikeRepoisoty commentLikeRepoisoty;
 
-    public List<CommentResponse> getCommentsNonLogin(Long postId) {
+    public List<CommentResponse> getComments(Long postId, LoginUser loginUser) {
         List<Comment> commentList = commentRepository.findAllByPostId(postId);
         List<CommentResponse> responseList = new ArrayList<>();
-
-        for (Comment comment : commentList) {
-            CommentResponse commentResponse = CommentResponse.builder()
-                .writer(comment.getUser().getUsername())
-                .content(comment.getContent())
-                .build();
-            responseList.add(commentResponse);
+        CommentResponse response;
+        List<CommentLike> commentLikeList = new ArrayList<>();
+        if(loginUser != null){
+            commentLikeList = commentLikeRepoisoty.findByUserId(loginUser.id());
         }
 
+        for (Comment comment : commentList) {
+
+            boolean likeStatus = false;
+
+            if(!commentLikeList.isEmpty()){
+                for (CommentLike commentLike : commentLikeList) {
+                    if(commentLike.getComment().equals(comment)){
+                        likeStatus = true;
+                        break;
+                    }
+                }
+            }
+            response = new CommentResponse(comment.getUser().getUsername(), comment.getContent(), likeStatus);
+            responseList.add(response);
+        }
         return responseList;
     }
 
-    public List<CommentResponse> getCommentsLogin(Long postId, LoginUser loginUser) {
-        return null;
+
+    // todo
+    public void deleteComment(Long id) {
+    }
+
+    // todo
+    public void deletePost(Long id) {
+
     }
 }

--- a/src/main/java/sssdev/tcc/domain/comment/service/CommentService.java
+++ b/src/main/java/sssdev/tcc/domain/comment/service/CommentService.java
@@ -11,9 +11,13 @@ import sssdev.tcc.domain.comment.dto.request.CommentCreateRequest;
 import sssdev.tcc.domain.comment.dto.response.CommentResponse;
 import sssdev.tcc.domain.comment.repository.CommentLikeRepoisoty;
 import sssdev.tcc.domain.comment.repository.CommentRepository;
+import sssdev.tcc.domain.post.domain.Post;
 import sssdev.tcc.domain.post.repository.PostRepository;
+import sssdev.tcc.domain.user.domain.User;
 import sssdev.tcc.domain.user.repository.UserRepository;
 import sssdev.tcc.global.common.dto.LoginUser;
+import sssdev.tcc.global.execption.ErrorCode;
+import sssdev.tcc.global.execption.ServiceException;
 
 @Service
 @RequiredArgsConstructor
@@ -52,6 +56,30 @@ public class CommentService {
     }
 
     public CommentResponse createComments(LoginUser loginUser, CommentCreateRequest requestDto) {
+        CommentResponse response;
+
+        User user = userRepository.findById(loginUser.id()).orElseThrow(
+            () -> new ServiceException(ErrorCode.NOT_EXIST_USER)
+        );
+
+        Post post = postRepository.findById(requestDto.postId()).orElseThrow(
+            () -> new ServiceException(ErrorCode.NOT_EXIST_POST)
+        );
+
+        Comment comment = Comment.builder()
+            .content(requestDto.content())
+            .user(user)
+            .post(post)
+            .build();
+
+        response = CommentResponse.builder()
+            .content(comment.getContent())
+            .writer(comment.getUser().getUsername())
+            .likeStatus(false)
+            .build();
+
+        commentRepository.save(comment);
+        return response;
     }
 
     // todo

--- a/src/main/java/sssdev/tcc/domain/comment/service/CommentService.java
+++ b/src/main/java/sssdev/tcc/domain/comment/service/CommentService.java
@@ -1,5 +1,38 @@
 package sssdev.tcc.domain.comment.service;
 
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import sssdev.tcc.domain.comment.domain.Comment;
+import sssdev.tcc.domain.comment.dto.response.CommentResponse;
+import sssdev.tcc.domain.comment.repository.CommentLikeRepoisoty;
+import sssdev.tcc.domain.comment.repository.CommentRepository;
+import sssdev.tcc.global.common.dto.LoginUser;
+
+@Service
+@RequiredArgsConstructor
 public class CommentService {
 
+    private final CommentRepository commentRepository;
+    private final CommentLikeRepoisoty commentLikeRepoisoty;
+
+    public List<CommentResponse> getCommentsNonLogin(Long postId) {
+        List<Comment> commentList = commentRepository.findAllByPostId(postId);
+        List<CommentResponse> responseList = new ArrayList<>();
+
+        for (Comment comment : commentList) {
+            CommentResponse commentResponse = CommentResponse.builder()
+                .writer(comment.getUser().getUsername())
+                .content(comment.getContent())
+                .build();
+            responseList.add(commentResponse);
+        }
+
+        return responseList;
+    }
+
+    public List<CommentResponse> getCommentsLogin(Long postId, LoginUser loginUser) {
+        return null;
+    }
 }

--- a/src/main/java/sssdev/tcc/global/execption/ErrorCode.java
+++ b/src/main/java/sssdev/tcc/global/execption/ErrorCode.java
@@ -13,7 +13,7 @@ public enum ErrorCode {
     CHECK_USER(HttpStatus.BAD_REQUEST, "1001", "본인이 아닙니다."),
 
     // post 2XXX
-
+    NOT_EXIST_POST(HttpStatus.BAD_REQUEST, "2000", "게시물이 없습니다."),
     // comment 3XXX
 
     // admin 4XXX

--- a/src/main/java/sssdev/tcc/global/util/StatusUtil.java
+++ b/src/main/java/sssdev/tcc/global/util/StatusUtil.java
@@ -30,7 +30,7 @@ public class StatusUtil {
         session.setMaxInactiveInterval(0);
     }
 
-    public boolean loginStatus(HttpServletRequest request) {
+    public boolean isLogin(HttpServletRequest request) {
         HttpSession session = request.getSession(false);
         return session != null;
     }

--- a/src/test/java/sssdev/tcc/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/sssdev/tcc/domain/comment/controller/CommentControllerTest.java
@@ -1,0 +1,51 @@
+package sssdev.tcc.domain.comment.controller;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import sssdev.tcc.domain.comment.dto.request.CommentCreateRequest;
+import sssdev.tcc.domain.comment.dto.response.CommentResponse;
+import sssdev.tcc.domain.comment.service.CommentService;
+import sssdev.tcc.support.ControllerTest;
+
+class CommentControllerTest extends ControllerTest {
+
+    @MockBean
+    CommentService commentService;
+
+    @Test
+    @DisplayName("게시물 내 댓글 전체 조회 - 비로그인 시")
+    void get_comments_test() throws Exception {
+
+        List<CommentResponse> responseList = new ArrayList<>();
+
+        for (int i = 0; i < 3; i++) {
+            CommentResponse response = new CommentResponse("작성자", "댓글 내용 " + i, null);
+            responseList.add(response);
+        }
+
+        given(commentService.getComments(any(), any())).willReturn(responseList);
+
+        String json = objectMapper.writeValueAsString(responseList);
+
+        mockMvc.perform(get("/api/comments"))
+            .andDo(print())
+            .andExpectAll(
+                status().isOk(),
+                jsonPath("$.data.size()").value(3),
+                jsonPath("$.data[0].content").value("댓글 내용 0"),
+                jsonPath("$.data[1].content").value("댓글 내용 1"),
+                jsonPath("$.data[2].content").value("댓글 내용 2")
+            );
+    }
+}

--- a/src/test/java/sssdev/tcc/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/sssdev/tcc/domain/comment/controller/CommentControllerTest.java
@@ -6,16 +6,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.BDDMockito;
+import org.junit.jupiter.params.shadow.com.univocity.parsers.annotations.Nested;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import sssdev.tcc.domain.comment.dto.request.CommentCreateRequest;
+import sssdev.tcc.domain.comment.dto.request.CommentRequest;
 import sssdev.tcc.domain.comment.dto.response.CommentResponse;
 import sssdev.tcc.domain.comment.service.CommentService;
+import sssdev.tcc.global.util.StatusUtil;
 import sssdev.tcc.support.ControllerTest;
 
 class CommentControllerTest extends ControllerTest {
@@ -23,29 +25,44 @@ class CommentControllerTest extends ControllerTest {
     @MockBean
     CommentService commentService;
 
-    @Test
-    @DisplayName("게시물 내 댓글 전체 조회 - 비로그인 시")
-    void get_comments_test() throws Exception {
+    @MockBean
+    StatusUtil statusUtil;
 
-        List<CommentResponse> responseList = new ArrayList<>();
+    @Nested
+    @DisplayName("게시물 내 댓글 전체 조회")
+    class get_comments_test {
 
-        for (int i = 0; i < 3; i++) {
-            CommentResponse response = new CommentResponse("작성자", "댓글 내용 " + i, null);
-            responseList.add(response);
+        @Test
+        @DisplayName("로그인을 하지 않았을 때 전체 조회 할 경우")
+        void get_comments_test() throws Exception {
+
+            CommentRequest request = new CommentRequest(1L);
+
+            List<CommentResponse> responseList = new ArrayList<>();
+
+            for (int i = 0; i < 3; i++) {
+                CommentResponse response = new CommentResponse("작성자", "댓글 내용 " + i, null);
+                responseList.add(response);
+            }
+
+            String json = objectMapper.writeValueAsString(request);
+
+            given(statusUtil.loginStatus(any(HttpServletRequest.class))).willReturn(true);
+            given(commentService.getCommentsNonLogin(any())).willReturn(responseList);
+
+            mockMvc.perform(get("/api/comments")
+                    .content(json)
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpectAll(
+                    status().isOk(),
+                    jsonPath("$.data.size()").value(3),
+                    jsonPath("$.data[0].content").value("댓글 내용 0"),
+                    jsonPath("$.data[1].content").value("댓글 내용 1"),
+                    jsonPath("$.data[2].content").value("댓글 내용 2")
+                );
         }
 
-        given(commentService.getComments(any(), any())).willReturn(responseList);
 
-        String json = objectMapper.writeValueAsString(responseList);
-
-        mockMvc.perform(get("/api/comments"))
-            .andDo(print())
-            .andExpectAll(
-                status().isOk(),
-                jsonPath("$.data.size()").value(3),
-                jsonPath("$.data[0].content").value("댓글 내용 0"),
-                jsonPath("$.data[1].content").value("댓글 내용 1"),
-                jsonPath("$.data[2].content").value("댓글 내용 2")
-            );
     }
 }

--- a/src/test/java/sssdev/tcc/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/sssdev/tcc/domain/comment/controller/CommentControllerTest.java
@@ -3,6 +3,7 @@ package sssdev.tcc.domain.comment.controller;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -15,10 +16,12 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import sssdev.tcc.domain.comment.dto.request.CommentCreateRequest;
 import sssdev.tcc.domain.comment.dto.request.CommentRequest;
 import sssdev.tcc.domain.comment.dto.response.CommentResponse;
 import sssdev.tcc.domain.comment.service.CommentService;
 import sssdev.tcc.domain.user.domain.User;
+import sssdev.tcc.domain.user.domain.UserRole;
 import sssdev.tcc.global.common.dto.LoginUser;
 import sssdev.tcc.global.util.StatusUtil;
 import sssdev.tcc.support.ControllerTest;
@@ -50,8 +53,8 @@ class CommentControllerTest extends ControllerTest {
 
             String json = objectMapper.writeValueAsString(request);
 
-            given(statusUtil.loginStatus(any())).willReturn(false);
-            given(commentService.getCommentsNonLogin(request.postId())).willReturn(responseList);
+            given(statusUtil.isLogin(any())).willReturn(false);
+            given(commentService.getComments(request.postId(), null)).willReturn(responseList);
 
             mockMvc.perform(
                     get("/api/comments").content(json).contentType(MediaType.APPLICATION_JSON))
@@ -65,7 +68,7 @@ class CommentControllerTest extends ControllerTest {
         @Test
         @DisplayName("로그인을 했을 때 전체 조회 할 경우")
         void get_comments_test_login() throws Exception {
-            LoginUser loginUser = new LoginUser(1L);
+            LoginUser loginUser = new LoginUser(1L, UserRole.USER);
 
             User user = User.builder().username("작성자").build();
             setField(user, "id", 1L);
@@ -81,16 +84,16 @@ class CommentControllerTest extends ControllerTest {
 
             String json = objectMapper.writeValueAsString(request);
 
-            given(statusUtil.loginStatus(any())).willReturn(true);
+            given(statusUtil.isLogin(any())).willReturn(true);
             given(statusUtil.getLoginUser(any())).willReturn(loginUser);
-            given(commentService.getCommentsLogin(any(), any()))
+            given(commentService.getComments(any(), any()))
                 .willReturn(responseList);
 
             mockMvc.perform(
-                get("/api/comments")
-                    .content(json)
-                    .contentType(MediaType.APPLICATION_JSON)
-            )
+                    get("/api/comments")
+                        .content(json)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
                 .andDo(print())
                 .andExpectAll(
                     status().isOk(),

--- a/src/test/java/sssdev/tcc/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/sssdev/tcc/domain/comment/controller/CommentControllerTest.java
@@ -10,8 +10,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.shadow.com.univocity.parsers.annotations.Nested;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import sssdev.tcc.domain.comment.dto.request.CommentRequest;
@@ -34,7 +34,7 @@ class CommentControllerTest extends ControllerTest {
 
         @Test
         @DisplayName("로그인을 하지 않았을 때 전체 조회 할 경우")
-        void get_comments_test() throws Exception {
+        void get_comments_test_not_login() throws Exception {
 
             CommentRequest request = new CommentRequest(1L);
 
@@ -47,7 +47,7 @@ class CommentControllerTest extends ControllerTest {
 
             String json = objectMapper.writeValueAsString(request);
 
-            given(statusUtil.loginStatus(any(HttpServletRequest.class))).willReturn(true);
+            given(statusUtil.loginStatus(any(HttpServletRequest.class))).willReturn(false);
             given(commentService.getCommentsNonLogin(any())).willReturn(responseList);
 
             mockMvc.perform(get("/api/comments")
@@ -63,6 +63,10 @@ class CommentControllerTest extends ControllerTest {
                 );
         }
 
+        @Test
+        @DisplayName("로그인을 했을 때 전체 조회 할 경우")
+        void get_comments_test_login() {
 
+        }
     }
 }

--- a/src/test/java/sssdev/tcc/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/sssdev/tcc/domain/comment/controller/CommentControllerTest.java
@@ -83,7 +83,7 @@ class CommentControllerTest extends ControllerTest {
 
             given(statusUtil.loginStatus(any())).willReturn(true);
             given(statusUtil.getLoginUser(any())).willReturn(loginUser);
-            given(commentService.getCommentsLogin(request.postId(), any()))
+            given(commentService.getCommentsLogin(any(), any()))
                 .willReturn(responseList);
 
             mockMvc.perform(
@@ -96,8 +96,8 @@ class CommentControllerTest extends ControllerTest {
                     status().isOk(),
                     jsonPath("$.data.size()").value(3),
                     jsonPath("$.data[0].likeStatus").value(true),
-                    jsonPath("$.data[0].likeStatus").value(false),
-                    jsonPath("$.data[0].likeStatus").value(true)
+                    jsonPath("$.data[1].likeStatus").value(false),
+                    jsonPath("$.data[2].likeStatus").value(true)
                 );
         }
     }

--- a/src/test/java/sssdev/tcc/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/sssdev/tcc/domain/comment/controller/CommentControllerTest.java
@@ -104,4 +104,37 @@ class CommentControllerTest extends ControllerTest {
                 );
         }
     }
+
+    @Nested
+    @DisplayName("게시물 내 댓글 생성")
+    class createComments {
+
+        @Test
+        @DisplayName("성공 테스트")
+        void create_comments_success() throws Exception {
+            LoginUser loginUser = new LoginUser(1L, UserRole.USER);
+            User user = User.builder().username("작성자").build();
+            setField(user, "id", 1L);
+
+            CommentCreateRequest request = new CommentCreateRequest("댓글 내용", 1L);
+            String json = objectMapper.writeValueAsString(request);
+
+            CommentResponse response = new CommentResponse(user.getUsername(), request.content(), false);
+
+            given(commentService.createComments(any(), any())).willReturn(response);
+
+            mockMvc.perform(
+                    post("/api/comments")
+                        .content(json)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpectAll(
+                    status().isOk(),
+                    jsonPath("$.code").value("200"),
+                    jsonPath("$.message").value("댓글 생성 성공"),
+                    jsonPath("$.data.writer").value("작성자")
+                );
+        }
+    }
 }

--- a/src/test/java/sssdev/tcc/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/sssdev/tcc/domain/comment/controller/CommentControllerTest.java
@@ -1,6 +1,7 @@
 package sssdev.tcc.domain.comment.controller;
 
 import static org.mockito.BDDMockito.*;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -17,6 +18,8 @@ import org.springframework.http.MediaType;
 import sssdev.tcc.domain.comment.dto.request.CommentRequest;
 import sssdev.tcc.domain.comment.dto.response.CommentResponse;
 import sssdev.tcc.domain.comment.service.CommentService;
+import sssdev.tcc.domain.user.domain.User;
+import sssdev.tcc.global.common.dto.LoginUser;
 import sssdev.tcc.global.util.StatusUtil;
 import sssdev.tcc.support.ControllerTest;
 
@@ -47,26 +50,55 @@ class CommentControllerTest extends ControllerTest {
 
             String json = objectMapper.writeValueAsString(request);
 
-            given(statusUtil.loginStatus(any(HttpServletRequest.class))).willReturn(false);
-            given(commentService.getCommentsNonLogin(any())).willReturn(responseList);
+            given(statusUtil.loginStatus(any())).willReturn(false);
+            given(commentService.getCommentsNonLogin(request.postId())).willReturn(responseList);
 
-            mockMvc.perform(get("/api/comments")
-                    .content(json)
-                    .contentType(MediaType.APPLICATION_JSON))
-                .andDo(print())
-                .andExpectAll(
-                    status().isOk(),
+            mockMvc.perform(
+                    get("/api/comments").content(json).contentType(MediaType.APPLICATION_JSON))
+                .andDo(print()).andExpectAll(status().isOk(),
                     jsonPath("$.data.size()").value(3),
                     jsonPath("$.data[0].content").value("댓글 내용 0"),
                     jsonPath("$.data[1].content").value("댓글 내용 1"),
-                    jsonPath("$.data[2].content").value("댓글 내용 2")
-                );
+                    jsonPath("$.data[2].content").value("댓글 내용 2"));
         }
 
         @Test
         @DisplayName("로그인을 했을 때 전체 조회 할 경우")
-        void get_comments_test_login() {
+        void get_comments_test_login() throws Exception {
+            LoginUser loginUser = new LoginUser(1L);
 
+            User user = User.builder().username("작성자").build();
+            setField(user, "id", 1L);
+
+            List<CommentResponse> responseList = new ArrayList<>();
+            CommentRequest request = new CommentRequest(1L);
+
+            for (int i = 0; i < 3; i++) {
+                CommentResponse response = new CommentResponse(user.getUsername(), "댓글 내용 " + i,
+                    i % 2 == 0);
+                responseList.add(response);
+            }
+
+            String json = objectMapper.writeValueAsString(request);
+
+            given(statusUtil.loginStatus(any())).willReturn(true);
+            given(statusUtil.getLoginUser(any())).willReturn(loginUser);
+            given(commentService.getCommentsLogin(request.postId(), any()))
+                .willReturn(responseList);
+
+            mockMvc.perform(
+                get("/api/comments")
+                    .content(json)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+                .andDo(print())
+                .andExpectAll(
+                    status().isOk(),
+                    jsonPath("$.data.size()").value(3),
+                    jsonPath("$.data[0].likeStatus").value(true),
+                    jsonPath("$.data[0].likeStatus").value(false),
+                    jsonPath("$.data[0].likeStatus").value(true)
+                );
         }
     }
 }

--- a/src/test/java/sssdev/tcc/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/sssdev/tcc/domain/comment/controller/CommentControllerTest.java
@@ -178,7 +178,7 @@ class CommentControllerTest extends ControllerTest {
                         .content(json)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
-                .andExpectAll(status().isBadRequest(),
+                .andExpectAll(status().isNotFound(),
                     jsonPath("$.code").value("2000"),
                     jsonPath("$.message").value("게시글이 없습니다.")
                 );

--- a/src/test/java/sssdev/tcc/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/sssdev/tcc/domain/comment/controller/CommentControllerTest.java
@@ -180,7 +180,7 @@ class CommentControllerTest extends ControllerTest {
                 .andDo(print())
                 .andExpectAll(status().isBadRequest(),
                     jsonPath("$.code").value("2000"),
-                    jsonPath("$.message").value("게시물이 없습니다.")
+                    jsonPath("$.message").value("게시글이 없습니다.")
                 );
         }
     }

--- a/src/test/java/sssdev/tcc/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/sssdev/tcc/domain/comment/repository/CommentRepositoryTest.java
@@ -1,0 +1,59 @@
+package sssdev.tcc.domain.comment.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import sssdev.tcc.domain.comment.domain.Comment;
+import sssdev.tcc.domain.post.domain.Post;
+import sssdev.tcc.domain.post.repository.PostRepository;
+import sssdev.tcc.domain.user.domain.User;
+import sssdev.tcc.domain.user.repository.UserRepository;
+import sssdev.tcc.support.RepositoryTest;
+
+class CommentRepositoryTest extends RepositoryTest {
+
+    @Autowired
+    CommentRepository commentRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    PostRepository postRepository;
+
+    @BeforeEach
+    void setUp() {
+        User user = User.builder().description("").nickname("")
+            .username("").password("").profileUrl("").build();
+        setField(user, "id", 1L);
+        Post post = Post.builder().content("").user(user).build();
+        setField(post, "id", 1L);
+
+        userRepository.save(user);
+        postRepository.save(post);
+
+        for (int i = 0; i < 10; i++) {
+            Comment comment = Comment.builder()
+                .content("댓글내용 " + i)
+                .user(user)
+                .post(post)
+                .build();
+            commentRepository.save(comment);
+        }
+    }
+
+    @Test
+    @DisplayName("해당 Post에 들어있는 모든 댓글을 조회하는 기능 테스트")
+    void findAllByPostIdTest() {
+        List<Comment> commentList = commentRepository.findAllByPostId(1L);
+
+        assertThat(commentList).hasSize(10);
+        assertThat(commentList.get(0).getContent()).isEqualTo("댓글내용 0");
+    }
+}

--- a/src/test/java/sssdev/tcc/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/sssdev/tcc/domain/comment/service/CommentServiceTest.java
@@ -1,16 +1,31 @@
 package sssdev.tcc.domain.comment.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import sssdev.tcc.domain.comment.domain.Comment;
+import sssdev.tcc.domain.comment.dto.response.CommentResponse;
 import sssdev.tcc.domain.comment.repository.CommentLikeRepoisoty;
 import sssdev.tcc.domain.comment.repository.CommentRepository;
+import sssdev.tcc.domain.post.domain.Post;
+import sssdev.tcc.domain.user.domain.User;
 
 @ExtendWith(MockitoExtension.class)
 class CommentServiceTest {
+
     @InjectMocks
     CommentService commentService;
 
@@ -19,5 +34,41 @@ class CommentServiceTest {
 
     @Mock
     CommentLikeRepoisoty commentLikeRepoisoty;
+
+    User user;
+    Post post;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder().username("작성자").build();
+        post = Post.builder().user(user).build();
+        setField(post, "id", 1L);
+    }
+
+    @Nested
+    @DisplayName("Post 안에 있는 모든 댓글 조회 테스트")
+    class get_comments_test {
+
+        @Test
+        @DisplayName("로그인 하지 않은 상태로 조회할 때")
+        void get_comments_test_not_login() {
+            List<Comment> commentList = new ArrayList<>();
+
+            for (int i = 0; i < 4; i++) {
+                Comment comment = Comment.builder().content("댓글 내용 " + i).user(user).post(post)
+                    .build();
+                commentList.add(comment);
+            }
+
+            given(commentRepository.findAllByPostId(post.getId())).willReturn(commentList);
+
+            List<CommentResponse> commentResponseList = commentService.getCommentsNonLogin(
+                post.getId());
+            assertThat(commentResponseList).hasSize(4);
+            assertThat(commentResponseList.get(0).content()).isEqualTo("댓글 내용 0");
+            assertThat(commentResponseList.get(1).content()).isEqualTo("댓글 내용 1");
+            assertThat(commentResponseList.get(2).content()).isEqualTo("댓글 내용 2");
+        }
+    }
 
 }

--- a/src/test/java/sssdev/tcc/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/sssdev/tcc/domain/comment/service/CommentServiceTest.java
@@ -1,0 +1,23 @@
+package sssdev.tcc.domain.comment.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sssdev.tcc.domain.comment.repository.CommentLikeRepoisoty;
+import sssdev.tcc.domain.comment.repository.CommentRepository;
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceTest {
+    @InjectMocks
+    CommentService commentService;
+
+    @Mock
+    CommentRepository commentRepository;
+
+    @Mock
+    CommentLikeRepoisoty commentLikeRepoisoty;
+
+}

--- a/src/test/java/sssdev/tcc/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/sssdev/tcc/domain/comment/service/CommentServiceTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -18,12 +19,15 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import sssdev.tcc.domain.comment.domain.Comment;
 import sssdev.tcc.domain.comment.domain.CommentLike;
+import sssdev.tcc.domain.comment.dto.request.CommentCreateRequest;
 import sssdev.tcc.domain.comment.dto.response.CommentResponse;
 import sssdev.tcc.domain.comment.repository.CommentLikeRepoisoty;
 import sssdev.tcc.domain.comment.repository.CommentRepository;
 import sssdev.tcc.domain.post.domain.Post;
+import sssdev.tcc.domain.post.repository.PostRepository;
 import sssdev.tcc.domain.user.domain.User;
 import sssdev.tcc.domain.user.domain.UserRole;
+import sssdev.tcc.domain.user.repository.UserRepository;
 import sssdev.tcc.global.common.dto.LoginUser;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,6 +41,10 @@ class CommentServiceTest {
 
     @Mock
     CommentLikeRepoisoty commentLikeRepoisoty;
+    @Mock
+    PostRepository postRepository;
+    @Mock
+    UserRepository userRepository;
 
     User user;
     Post post;
@@ -108,5 +116,19 @@ class CommentServiceTest {
             assertThat(responseList.get(2).likeStatus()).isEqualTo(true);
         }
 
+    }
+
+    @Test
+    @DisplayName("댓글 작성 성공 테스트")
+    void create_comments_test_success() {
+        LoginUser loginUser = new LoginUser(1L, UserRole.USER);
+        CommentCreateRequest request = new CommentCreateRequest("댓글 내용", 1L);
+        given(postRepository.findById(request.postId())).willReturn(Optional.of(post));
+        given(userRepository.findById(loginUser.id())).willReturn(Optional.of(user));
+
+        CommentResponse response = commentService.createComments(loginUser, request);
+
+        assertThat(response.content()).isEqualTo("댓글 내용");
+        assertThat(response.writer()).isEqualTo(user.getUsername());
     }
 }

--- a/src/test/java/sssdev/tcc/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/sssdev/tcc/domain/comment/service/CommentServiceTest.java
@@ -170,7 +170,7 @@ class CommentServiceTest {
             ServiceException exception = assertThrows(ServiceException.class,
                 () -> commentService.createComments(loginUser, request));
 
-            assertThat(exception.getCode().getMessage()).isEqualTo("게시물이 없습니다.");
+            assertThat(exception.getCode().getMessage()).isEqualTo("게시글이 없습니다.");
             assertThat(exception.getCode().getCode()).isEqualTo("2000");
         }
     }


### PR DESCRIPTION
## 개요
원하는 게시물에 있는 댓글을 전체 조회하는 API 및 API 테스트 코드 구현
원하는 게시물에 댓글 작성하는 API 및 API 테스트 코드 구현

## 작업사항
- 로그인 / 비로그인 시 댓글을 봤을 때 달라지는 부분 구현
- 게시물 안에 있는 댓글 전체 조회하는 기능 구현
- 위 기능의 테스트 코드 구현

- 게시물에 댓글 작성하는 기능 구현
- 게시물 댓글 작성 기능 테스트 코드 구현 및 예외처리

## 변경로직
- X

## 관련 이슈
- Closed #49 
- Closed #51 