### PR TITLE
Feat/add post like api

### DIFF
--- a/src/main/java/sssdev/tcc/domain/post/controller/PostController.java
+++ b/src/main/java/sssdev/tcc/domain/post/controller/PostController.java
@@ -120,4 +120,32 @@ public class PostController {
 
         return ResponseEntity.ok().build();
     }
+
+    /**
+     * 게시글 좋아요 추가
+     */
+    @PostMapping("/{id}/like")
+    public ResponseEntity<?> likePost(
+        @PathVariable(name = "id") Long id,
+        HttpServletRequest request) {
+
+        LoginUser loginUser = statusUtil.getLoginUser(request);
+        postService.likePost(id, loginUser);
+
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 게시글 좋아요 삭제
+     */
+    @DeleteMapping("/{id}/like")
+    public ResponseEntity<?> unlikePost(
+        @PathVariable(name = "id") Long id,
+        HttpServletRequest request) {
+
+        LoginUser loginUser = statusUtil.getLoginUser(request);
+        postService.unlikePost(id, loginUser);
+
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/sssdev/tcc/domain/post/domain/Post.java
+++ b/src/main/java/sssdev/tcc/domain/post/domain/Post.java
@@ -61,4 +61,19 @@ public class Post extends BaseEntity {
     public void updateContent(PostUpdateRequest request) {
         this.content = request.getContent();
     }
+
+    public void like(User user) {
+
+        PostLike postLike = PostLike
+            .builder()
+            .post(this)
+            .user(user)
+            .build();
+
+        postLikeList.add(postLike);
+    }
+
+    public void unlike(PostLike postLike) {
+        postLikeList.remove(postLike);
+    }
 }

--- a/src/main/java/sssdev/tcc/domain/post/domain/PostLike.java
+++ b/src/main/java/sssdev/tcc/domain/post/domain/PostLike.java
@@ -1,6 +1,7 @@
 package sssdev.tcc.domain.post.domain;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -17,11 +18,11 @@ import sssdev.tcc.domain.user.domain.User;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostLike extends BaseEntity {
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 

--- a/src/main/java/sssdev/tcc/domain/post/repository/PostLikeRepository.java
+++ b/src/main/java/sssdev/tcc/domain/post/repository/PostLikeRepository.java
@@ -1,5 +1,6 @@
 package sssdev.tcc.domain.post.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import sssdev.tcc.domain.post.domain.PostLike;
 
@@ -8,4 +9,6 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     long countByPostId(Long postId);
 
     boolean existsByUserIdAndPostId(Long userId, Long postId);
+
+    Optional<PostLike> findByUserIdAndPostId(Long userId, Long postId);
 }

--- a/src/main/java/sssdev/tcc/domain/post/service/PostService.java
+++ b/src/main/java/sssdev/tcc/domain/post/service/PostService.java
@@ -134,6 +134,35 @@ public class PostService {
         }
     }
 
+    /**
+     * 게시글 좋아요 추가
+     */
+    @Transactional
+    public void likePost(Long id, LoginUser loginUser) {
+
+        Post post = postRepository.findById(id)
+            .orElseThrow(() -> new ServiceException(NOT_EXIST_POST));
+
+        User user = userRepository.findById(loginUser.id())
+            .orElseThrow(() -> new ServiceException(NOT_EXIST_USER));
+
+        post.like(user);
+    }
+
+    /**
+     * 게시글 좋아요 삭제
+     */
+    @Transactional
+    public void unlikePost(Long id, LoginUser loginUser) {
+
+        Post post = postRepository.findById(id)
+            .orElseThrow(() -> new ServiceException(NOT_EXIST_POST));
+
+        postLikeRepository
+            .findByUserIdAndPostId(loginUser.id(), id)
+            .ifPresent(post::unlike);
+    }
+
     // todo
     @Transactional
     public AdminPostUpdateResponse updatePostAdmin(Long id, AdminPostUpdateRequest request) {

--- a/src/main/java/sssdev/tcc/domain/post/service/PostService.java
+++ b/src/main/java/sssdev/tcc/domain/post/service/PostService.java
@@ -117,6 +117,7 @@ public class PostService {
     /**
      * 게시글 삭제
      */
+    @Transactional
     public void delete(Long id, LoginUser loginUser) {
 
         Post post = postRepository.findById(id)

--- a/src/test/java/sssdev/tcc/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/sssdev/tcc/domain/post/controller/PostControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.util.ReflectionTestUtils.setField;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -390,6 +391,55 @@ class PostControllerTest extends ControllerTest {
 
             // when && then
             mockMvc.perform(delete("/api/posts/{id}", post1.getId()))
+                .andDo(print())
+                .andExpectAll(
+                    status().isOk()
+                );
+        }
+    }
+
+    @Nested
+    @DisplayName("게시글 좋아요")
+    class PostLike {
+
+        @DisplayName("성공 케이스 - 게시글 좋아요 추가")
+        @Test
+        void like_post_success() throws Exception {
+            // given
+            User user = User.builder().username("username").build();
+            setField(user, "id", 1L);
+            LoginUser loginUser = new LoginUser(user.getId(), UserRole.USER);
+
+            Post post1 = Post.builder().content("content02").user(user).build();
+            setField(post1, "id", 1L);
+
+            given(statusUtil.getLoginUser(any(HttpServletRequest.class)))
+                .willReturn(loginUser);
+
+            // when && then
+            mockMvc.perform(post("/api/posts/{id}/like", post1.getId()))
+                .andDo(print())
+                .andExpectAll(
+                    status().isOk()
+                );
+        }
+
+        @DisplayName("성공 케이스 - 게시글 좋아요 삭제")
+        @Test
+        void unlike_post_success() throws Exception {
+            // given
+            User user = User.builder().username("username").build();
+            setField(user, "id", 1L);
+            LoginUser loginUser = new LoginUser(user.getId(), UserRole.USER);
+
+            Post post1 = Post.builder().content("content02").user(user).build();
+            setField(post1, "id", 1L);
+
+            given(statusUtil.getLoginUser(any(HttpServletRequest.class)))
+                .willReturn(loginUser);
+
+            // when && then
+            mockMvc.perform(delete("/api/posts/{id}/like", post1.getId()))
                 .andDo(print())
                 .andExpectAll(
                     status().isOk()

--- a/src/test/java/sssdev/tcc/domain/post/service/PostServiceTest.java
+++ b/src/test/java/sssdev/tcc/domain/post/service/PostServiceTest.java
@@ -441,4 +441,42 @@ class PostServiceTest {
                 });
         }
     }
+
+    @Nested
+    @DisplayName("게시글 좋아요")
+    class PostLike {
+
+        @DisplayName("성공 케이스 - 게시글 좋아요 추가")
+        @Test
+        void post_like_success() {
+            // given
+            User user = User.builder().username("username01").build();
+            setField(user, "id", 1L);
+            LoginUser loginUser = new LoginUser(user.getId(), UserRole.USER);
+            Post post1 = Post.builder().content("content01").user(user).build();
+            setField(post1, "id", 1L);
+
+            given(postRepository.findById(anyLong())).willReturn(Optional.of(post1));
+            given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+
+            // when && then
+            postService.likePost(post1.getId(), loginUser);
+        }
+
+        @DisplayName("성공 케이스 - 게시글 좋아요 삭제")
+        @Test
+        void post_unlike_success() {
+            // given
+            User user = User.builder().username("username01").build();
+            setField(user, "id", 1L);
+            LoginUser loginUser = new LoginUser(user.getId(), UserRole.USER);
+            Post post1 = Post.builder().content("content01").user(user).build();
+            setField(post1, "id", 1L);
+
+            given(postRepository.findById(anyLong())).willReturn(Optional.of(post1));
+
+            // when && then
+            postService.unlikePost(post1.getId(), loginUser);
+        }
+    }
 }

--- a/src/test/java/sssdev/tcc/domain/post/service/PostServiceTest.java
+++ b/src/test/java/sssdev/tcc/domain/post/service/PostServiceTest.java
@@ -366,79 +366,79 @@ class PostServiceTest {
                     assertThat(errorCode.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED);
                 });
         }
+    }
 
-        @Nested
-        @DisplayName("게시글 삭제")
-        class DeletePost {
+    @Nested
+    @DisplayName("게시글 삭제")
+    class DeletePost {
 
-            @DisplayName("성공 케이스 - 게시글 삭제 성공")
-            @Test
-            void delete_post_success() {
-                // given
-                User user = User.builder().username("username01").build();
-                setField(user, "id", 1L);
-                LoginUser loginUser = new LoginUser(user.getId(), UserRole.USER);
-                Post post1 = Post.builder().content("content01").user(user).build();
-                setField(post1, "id", 1L);
+        @DisplayName("성공 케이스 - 게시글 삭제 성공")
+        @Test
+        void delete_post_success() {
+            // given
+            User user = User.builder().username("username01").build();
+            setField(user, "id", 1L);
+            LoginUser loginUser = new LoginUser(user.getId(), UserRole.USER);
+            Post post1 = Post.builder().content("content01").user(user).build();
+            setField(post1, "id", 1L);
 
-                given(postRepository.findById(post1.getId())).willReturn(Optional.of(post1));
+            given(postRepository.findById(post1.getId())).willReturn(Optional.of(post1));
 
-                // when
-                postService.delete(post1.getId(), loginUser);
+            // when
+            postService.delete(post1.getId(), loginUser);
 
-                // then
-                then(postRepository).should().delete(post1);
-            }
+            // then
+            then(postRepository).should().delete(post1);
+        }
 
-            @DisplayName("실패 케이스 - 없는 게시글")
-            @Test
-            void delete_post_fail_not_exist_post() {
-                // given
-                User user = User.builder().username("username01").build();
-                setField(user, "id", 1L);
-                LoginUser loginUser = new LoginUser(user.getId(), UserRole.USER);
-                Post post1 = Post.builder().content("content01").user(user).build();
-                setField(post1, "id", 1L);
+        @DisplayName("실패 케이스 - 없는 게시글")
+        @Test
+        void delete_post_fail_not_exist_post() {
+            // given
+            User user = User.builder().username("username01").build();
+            setField(user, "id", 1L);
+            LoginUser loginUser = new LoginUser(user.getId(), UserRole.USER);
+            Post post1 = Post.builder().content("content01").user(user).build();
+            setField(post1, "id", 1L);
 
-                given(postRepository.findById(post1.getId()))
-                    .willThrow(new ServiceException(NOT_EXIST_POST));
+            given(postRepository.findById(post1.getId()))
+                .willThrow(new ServiceException(NOT_EXIST_POST));
 
-                // when && then
-                assertThatThrownBy(() -> postService
-                    .delete(post1.getId(), loginUser))
-                    .isInstanceOf(ServiceException.class)
-                    .satisfies(exception -> {
-                        ErrorCode errorCode = ((ServiceException) exception).getCode();
-                        assertThat(errorCode.getCode()).isEqualTo("2000");
-                        assertThat(errorCode.getMessage()).isEqualTo("게시글이 없습니다.");
-                        assertThat(errorCode.getStatus()).isEqualTo(NOT_FOUND);
-                    });
-            }
+            // when && then
+            assertThatThrownBy(() -> postService
+                .delete(post1.getId(), loginUser))
+                .isInstanceOf(ServiceException.class)
+                .satisfies(exception -> {
+                    ErrorCode errorCode = ((ServiceException) exception).getCode();
+                    assertThat(errorCode.getCode()).isEqualTo("2000");
+                    assertThat(errorCode.getMessage()).isEqualTo("게시글이 없습니다.");
+                    assertThat(errorCode.getStatus()).isEqualTo(NOT_FOUND);
+                });
+        }
 
-            @DisplayName("실패 케이스 - 작성자가 아닌 사용자")
-            @Test
-            void delete_post_fail_unauthorized() {
-                // given
-                User user = User.builder().username("username01").build();
-                setField(user, "id", 1L);
-                LoginUser loginUser = new LoginUser(user.getId(), UserRole.USER);
-                Post post1 = Post.builder().content("content01").user(user).build();
-                setField(post1, "id", 1L);
+        @DisplayName("실패 케이스 - 작성자가 아닌 사용자")
+        @Test
+        void delete_post_fail_unauthorized() {
+            // given
+            User user = User.builder().username("username01").build();
+            setField(user, "id", 1L);
+            LoginUser loginUser = new LoginUser(user.getId(), UserRole.USER);
+            Post post1 = Post.builder().content("content01").user(user).build();
+            setField(post1, "id", 1L);
 
-                given(postRepository.findById(post1.getId()))
-                    .willThrow(new ServiceException(UNAUTHORIZED));
+            given(postRepository.findById(post1.getId()))
+                .willThrow(new ServiceException(UNAUTHORIZED));
 
-                // when && then
-                assertThatThrownBy(() -> postService
-                    .delete(post1.getId(), loginUser))
-                    .isInstanceOf(ServiceException.class)
-                    .satisfies(exception -> {
-                        ErrorCode errorCode = ((ServiceException) exception).getCode();
-                        assertThat(errorCode.getCode()).isEqualTo("5001");
-                        assertThat(errorCode.getMessage()).isEqualTo("권한이 없습니다.");
-                        assertThat(errorCode.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED);
-                    });
-            }
+            // when && then
+            assertThatThrownBy(() -> postService
+                .delete(post1.getId(), loginUser))
+                .isInstanceOf(ServiceException.class)
+                .satisfies(exception -> {
+                    ErrorCode errorCode = ((ServiceException) exception).getCode();
+                    assertThat(errorCode.getCode()).isEqualTo("5001");
+                    assertThat(errorCode.getMessage()).isEqualTo("권한이 없습니다.");
+                    assertThat(errorCode.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED);
+                });
         }
     }
 }


### PR DESCRIPTION
## 개요
게시글 좋아요 추가 및 삭제 API 추가 

## 작업사항
- 게시글 좋아요 API 추가 
- 게시글 좋아요 취소 API 추가 
- 게시글 좋아요 관련 테스트 코드 추가 

## 변경로직
- PostLike 엔티티의 `@ManyToOne` fetch 타입을 LAZY로 변경 

## 관련 이슈
- #55 
