### PR TITLE
예외처리 테스트 추가 및 nickname으로 변경

### DIFF
--- a/src/main/java/sssdev/tcc/domain/comment/controller/CommentController.java
+++ b/src/main/java/sssdev/tcc/domain/comment/controller/CommentController.java
@@ -102,7 +102,7 @@ public class CommentController {
     }
 
     @DeleteMapping("/comments/{id}/like")
-    public ResponseEntity<?> cancleLikeComments(@PathVariable(name = "id") Long id,
+    public ResponseEntity<?> cancelLikeComments(@PathVariable(name = "id") Long id,
         HttpServletRequest servletRequest) {
         LoginUser loginUser = statusUtil.getLoginUser(servletRequest);
         CommentResponse response = commentService.cancelLikeComments(id, loginUser);

--- a/src/main/java/sssdev/tcc/domain/comment/service/CommentService.java
+++ b/src/main/java/sssdev/tcc/domain/comment/service/CommentService.java
@@ -25,7 +25,6 @@ import sssdev.tcc.domain.post.repository.PostRepository;
 import sssdev.tcc.domain.user.domain.User;
 import sssdev.tcc.domain.user.repository.UserRepository;
 import sssdev.tcc.global.common.dto.LoginUser;
-import sssdev.tcc.global.execption.ErrorCode;
 import sssdev.tcc.global.execption.ServiceException;
 
 @Service
@@ -58,7 +57,7 @@ public class CommentService {
                     }
                 }
             }
-            response = new CommentResponse(comment.getUser().getUsername(), comment.getContent(), likeStatus);
+            response = new CommentResponse(comment.getUser().getNickname(), comment.getContent(), likeStatus);
             responseList.add(response);
         }
         return responseList;
@@ -124,7 +123,7 @@ public class CommentService {
 
         comment.updateComment(request.content());
 
-        return new CommentResponse(user.getUsername(), comment.getContent(), likeStatus);
+        return new CommentResponse(user.getNickname(), comment.getContent(), likeStatus);
     }
 
     public void deleteComments(Long id, LoginUser loginUser) {
@@ -163,7 +162,7 @@ public class CommentService {
 
         commentLikeRepoisoty.save(commentLike);
 
-        return new CommentResponse(comment.getUser().getUsername(), comment.getContent(), likeStatus);
+        return new CommentResponse(comment.getUser().getNickname(), comment.getContent(), likeStatus);
     }
 
     public CommentResponse cancelLikeComments(Long id, LoginUser loginUser) {
@@ -182,8 +181,6 @@ public class CommentService {
 
         commentLikeRepoisoty.delete(commentLike);
 
-        return new CommentResponse(comment.getUser().getUsername(), comment.getContent(), likeStatus);
+        return new CommentResponse(comment.getUser().getNickname(), comment.getContent(), likeStatus);
     }
-
-
 }


### PR DESCRIPTION
## 개요
예외처리 테스트 추가 및 username을 nickname으로 변경

## 작업사항
- 자신의 댓글이 아닌 것을 수정할 때 실패 테스트 구현
- nickname이 나오도록 변경

## 변경로직
- username -> nickname

## 관련 이슈
- 
